### PR TITLE
couleur de sous-titre plus lisible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -33,7 +33,7 @@ header {
 
 header p {
   font-family: 'Allura';
-  color: rgba(255, 255, 255, 0.2);
+  color: rgba(200, 185, 227, 1);
   margin-bottom: 0;
   font-size: 45px;
   margin-top: -10px;


### PR DESCRIPTION
Surtout pour essayer. Et accessoirement rendre le sous-titre plus lisible en virant le canal alpha sur le texte. C'est pas passé loin du point "comic sans MS".